### PR TITLE
Refactor Element Methods

### DIFF
--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -23,4 +23,12 @@ public extension Element {
             return textContent
         }
     }
+
+    /// Returns the number of times a given string appears.
+    ///
+    /// - Parameter s: The string to count.
+    /// - Returns: The number of times the given string appears.
+    func getCharCount(s: String = ",") throws -> Int {
+        try getInnerText().rangesOfString(s: s).count
+    }
 }

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -31,4 +31,11 @@ public extension Element {
     func getCharCount(s: String = ",") throws -> Int {
         try getInnerText().rangesOfString(s: s).count
     }
+
+    /// Removes the style attribute.
+    func cleanStyles() throws {
+        try getAllElements().array().forEach {
+            try $0.removeAttr("style")
+        }
+    }
 }

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -89,6 +89,35 @@ public extension Element {
         return weight
     }
 
+    /// Clean a node of all elements of a given tag (unless it's a youtube/vimeo video; people love movies).
+    /// - Parameter tag: The elements to clean.
+    func clean(tag: String) throws {
+        let isEmbed = (tag == "iframe" || tag == "object" || tag == "embed")
+        for element in try getElementsByTag(tag).array() {
+            // Allow youtube and vimeo videos through as people usually want to see those.
+            if isEmbed {
+                var attributeValues = ""
+                if let attributes = element.getAttributes() {
+                    for il in attributes {
+                        attributeValues = il.getValue() + "|" // DOMAttr?
+                    }
+                }
+
+                // First, check the elements attributes to see if any of them contain youtube or vimeo
+                if attributeValues.matches(RegEx.video) {
+                    continue
+                }
+
+                // Then check the elements inside this element for the same.
+                if try element.html().matches(RegEx.video) {
+                    continue
+                }
+            }
+
+            try element.parent()?.removeChild(element)
+        }
+    }
+
     /// Clean out spurious headers from an Element. Checks things like classnames and link density.
     ///
     /// - Parameter getClassWeight: A Boolean value indicated whether class weights should be calculated.

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -134,3 +134,16 @@ public extension Element {
         }
     }
 }
+
+internal extension Element {
+    /// Reverts P elements with class `readability-styled` to text nodes - which is what they were before.
+    func revertReadabilityStyledElements() throws {
+        guard let owner = ownerDocument() else {
+            return
+        }
+
+        for element in try select("p.readability-styled").array() {
+            try element.parent()?.replaceChild(owner.appendText(element.text()), element)
+        }
+    }
+}

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -38,4 +38,23 @@ public extension Element {
             try $0.removeAttr("style")
         }
     }
+
+    /// Returns the density of links as a percentage of content.
+    ///
+    /// This is the amount of text that is inside a link divided by the total text in the node.
+    func getLinkDensity() throws -> Float {
+        let links = try getElementsByTag("a")
+        let textLength = try getInnerText().count
+        var linkLength = 0
+
+        for link in links {
+            linkLength += try link.getInnerText().count
+        }
+
+        if textLength > 0 {
+            return Float(linkLength / textLength)
+        } else {
+            return 0
+        }
+    }
 }

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -57,4 +57,35 @@ public extension Element {
             return 0
         }
     }
+
+    /// Returns the element's class/id weight.
+    ///
+    /// Uses regular expressions to tell if this element looks good or bad.
+    func getClassWeight() throws -> Int {
+        var weight = 0
+
+        // Look for a special classname
+        if try hasAttr("class") && attr("class") != "" {
+            if try attr("class").matches(RegEx.negative) {
+                weight -= 25
+            }
+
+            if try attr("class").matches(RegEx.positive) {
+                weight += 25
+            }
+        }
+
+        // Look for a special ID
+        if try hasAttr("id") && attr("id") != "" {
+            if try attr("id").matches(RegEx.negative) {
+                weight -= 25
+            }
+
+            if try attr("id").matches(RegEx.positive) {
+                weight += 25
+            }
+        }
+
+        return weight
+    }
 }

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -88,4 +88,20 @@ public extension Element {
 
         return weight
     }
+
+    /// Clean out spurious headers from an Element. Checks things like classnames and link density.
+    ///
+    /// - Parameter getClassWeight: A Boolean value indicated whether class weights should be calculated.
+    func cleanHeaders(getClassWeight: Bool) throws {
+        for headerIndex in 1 ... 2 {
+            for header in try getElementsByTag("h\(headerIndex)").array()  {
+                let classWeight = getClassWeight ? try header.getClassWeight() : 0
+                let linkDensity = try header.getLinkDensity()
+
+                if classWeight < 0 || linkDensity > 0.33 {
+                    try header.parent()?.removeChild(header)
+                }
+            }
+        }
+    }
 }

--- a/Sources/Readability/Element+Utils.swift
+++ b/Sources/Readability/Element+Utils.swift
@@ -1,0 +1,26 @@
+//
+//  Element+Utils.swift
+//  
+//
+//  Created by Mathew Gacy on 5/28/23.
+//
+
+import Foundation
+import SwiftSoup
+
+public extension Element {
+    /// Returns the inner text.
+    ///
+    /// This also strips out any excess whitespace to be found.
+    ///
+    /// - Parameter normalizeSpaces: A Boolean value indicating whether spaces should be normalized.
+    /// - Returns: The inner text.
+    func getInnerText(normalizeSpaces: Bool = true) throws -> String {
+        let textContent = try text().trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizeSpaces {
+            return textContent.replacingOccurrences(of: RegEx.normalize, with: " ")
+        } else {
+            return textContent
+        }
+    }
+}

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -722,7 +722,7 @@ public class Readability {
 
         clean(articleContent, tag: "iframe")
 
-        cleanHeaders(articleContent)
+        try! articleContent.cleanHeaders(getClassWeight: flagIsActive(flag: FLAG_WEIGHT_CLASSES))
 
         /* Do these last as the previous stuff may have removed junk that will affect these */
         cleanConditionally(articleContent, tag: "table")
@@ -1308,25 +1308,6 @@ public class Readability {
 
                 if toRemove {
                     try! tag.parent()?.removeChild(tag)
-                }
-            }
-        }
-    }
-
-    /**
-     * Clean out spurious headers from an Element. Checks things like classnames and link density.
-     *
-     * @param DOMElement $e
-     * @return void
-     */
-    public func cleanHeaders(_ e: Element) {
-        for headerIndex in 1 ... 2 {
-            let headers = try! e.getElementsByTag("h\(headerIndex)").array()
-
-            for header in headers {
-                let classWeight = flagIsActive(flag: FLAG_WEIGHT_CLASSES) ? try! header.getClassWeight() : 0
-                if classWeight < 0 || (try! header.getLinkDensity()) > 0.33 {
-                    try! header.parent()?.removeChild(header)
                 }
             }
         }

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -700,7 +700,7 @@ public class Readability {
      * @return void
      */
     public func prepArticle(_ articleContent: Element) {
-        cleanStyles(articleContent)
+        try! articleContent.cleanStyles()
         killBreaks(articleContent)
 
         if revertForcedParagraphElements {
@@ -1120,20 +1120,6 @@ public class Readability {
 
         for script in noscripts {
             try! script.parent()?.removeChild(script)
-        }
-    }
-
-    /**
-     * Remove the style attribute on every $e and under.
-     *
-     * @param DOMElement $e
-     * @return void
-     */
-    public func cleanStyles(_ e: Element) {
-        let elems = try! e.getAllElements().array()
-
-        for elem in elems {
-            try! elem.removeAttr("style")
         }
     }
 

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -1124,17 +1124,6 @@ public class Readability {
     }
 
     /**
-     * Get the number of times a string $s appears in the node $e.
-     *
-     * @param DOMElement $e
-     * @param string - what to count. Default is ","
-     * @return number (integer)
-     **/
-    public func getCharCount(_ e: Element, s: String = ",") -> Int {
-        return try! e.getInnerText().rangesOfString(s: s).count
-    }
-
-    /**
      * Remove the style attribute on every $e and under.
      *
      * @param DOMElement $e
@@ -1293,7 +1282,7 @@ public class Readability {
 
             if weight + contentScore < 0 {
                 try! tag.parent()?.removeChild(tag)
-            } else if getCharCount(tag, s: ",") < 10 {
+            } else if try! tag.getCharCount(s: ",") < 10 {
                 /**
                  * If there are not very many commas, and the number of
                  * non-paragraph elements is more than paragraphs or other ominous signs, remove the element.

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -709,18 +709,18 @@ public class Readability {
 
         /* Clean out junk from the article content */
         cleanConditionally(articleContent, tag: "form")
-        clean(articleContent, tag: "object")
-        clean(articleContent, tag: "h1")
+        try! articleContent.clean(tag: "object")
+        try! articleContent.clean(tag: "h1")
 
         /**
          * If there is only one h2, they are probably using it
          * as a header and not a subheader, so remove it since we already have a header.
          ***/
         if !lightClean && (try! articleContent.getElementsByTag("h2").array().count == 1) {
-            clean(articleContent, tag: "h2")
+            try! articleContent.clean(tag: "h2")
         }
 
-        clean(articleContent, tag: "iframe")
+        try! articleContent.clean(tag: "iframe")
 
         try! articleContent.cleanHeaders(getClassWeight: flagIsActive(flag: FLAG_WEIGHT_CLASSES))
 
@@ -1137,44 +1137,6 @@ public class Readability {
         html = html.replacingOccurrences(of: RegEx.killBreaks, with: "<br />")
 
         try! node.html(html)
-    }
-
-    /**
-     * Clean a node of all elements of type "tag".
-     * (Unless it's a youtube/vimeo video. People love movies.)
-     *
-     * Updated 2012-09-18 to preserve youtube/vimeo iframes
-     *
-     * @param DOMElement $e
-     * @param string $tag
-     * @return void
-     */
-    public func clean(_ e: Element, tag: String) {
-        let targetList = try! e.getElementsByTag(tag).array()
-        let isEmbed = (tag == "iframe" || tag == "object" || tag == "embed")
-
-        for y in targetList {
-            /* Allow youtube and vimeo videos through as people usually want to see those. */
-            if isEmbed {
-                var attributeValues = ""
-
-                for il in y.getAttributes()! {
-                    attributeValues = il.getValue() + "|" // DOMAttr?
-                }
-
-                /* First, check the elements attributes to see if any of them contain youtube or vimeo */
-                if attributeValues.matches(RegEx.video) {
-                    continue
-                }
-
-                /* Then check the elements inside this element for the same. */
-                if try! y.html().matches(RegEx.video) {
-                    continue
-                }
-            }
-
-            try! y.parent()?.removeChild(y)
-        }
     }
 
     /**

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -676,23 +676,6 @@ public class Readability {
     }
 
     /**
-     * Reverts P elements with class "readability-styled"
-     * to text nodes - which is what they were before.
-     *
-     * @param DOMElement
-     * @return void
-     */
-    func revertReadabilityStyledElements(_ articleContent: Element) {
-        let elems = try! articleContent.select("p.readability-styled").array()
-
-        // $elems = $articleContent->getElementsByTagName("p");
-
-        for e in elems {
-            try! e.parent()?.replaceChild((articleContent.ownerDocument()?.appendText(e.text()))!, e)
-        }
-    }
-
-    /**
      * Prepare the article node for display. Clean out any inline styles,
      * iframes, forms, strip extraneous <p> tags, etc.
      *
@@ -704,7 +687,7 @@ public class Readability {
         killBreaks(articleContent)
 
         if revertForcedParagraphElements {
-            revertReadabilityStyledElements(articleContent)
+            try! articleContent.revertReadabilityStyledElements()
         }
 
         /* Clean out junk from the article content */

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -144,7 +144,7 @@ public class Readability {
         var articleContent = try! dom.createElement("div")
 
         let main = try! dom.getElementsByClass("inner-content").first()!
-        let title = getInnerText(try! main.select("#question-header h1 a.question-hyperlink").first()!)
+        let title = try! main.select("#question-header h1 a.question-hyperlink").first()!.getInnerText()
 
         let articleTitleh1 = try! dom.createElement("h1")
         try! articleTitleh1.text(title)
@@ -163,7 +163,7 @@ public class Readability {
         let answersTitleEl = try! answersDiv.select("#answers-header .answers-subheader h2").first()!
         let extraSpan = try! answersTitleEl.select("span").last()!
         try! extraSpan.remove()
-        let answersTitle = getInnerText(answersTitleEl)
+        let answersTitle = try! answersTitleEl.getInnerText()
         let acceptedAnswer = try! answersDiv.select(".answer.accepted-answer")
 
         let otherAnswers = try! answersDiv.select(".answer").not(".accepted-answer").array()
@@ -203,7 +203,7 @@ public class Readability {
             }
         }
 
-        if getInnerText(articleContent) == "" {
+        if try! articleContent.getInnerText() == "" {
             success = false
 
             articleContent = try! dom.createElement("div")
@@ -269,7 +269,7 @@ public class Readability {
 
         let main = try! dom.select("#main-content .page").first()!
         let question = try! main.select("#question-container").first()!
-        let title = getInnerText(try! question.select(".header h1.title").first()!)
+        let title = try! question.select(".header h1.title").first()!.getInnerText()
 
         let articleTitleh1 = try! dom.createElement("h1")
         try! articleTitleh1.text(title)
@@ -290,7 +290,7 @@ public class Readability {
             }
         }
 
-        if getInnerText(articleContent) == "" {
+        if try! articleContent.getInnerText() == "" {
             success = false
 
             articleContent = try! dom.createElement("div")
@@ -457,7 +457,7 @@ public class Readability {
             if h1s.count == 1 {
                 let h1 = h1s.first()!
                 let articleTitle = try! dom.createElement("h1")
-                try! articleTitle.text(getInnerText(h1))
+                try! articleTitle.text(h1.getInnerText())
                 self.articleTitle = articleTitle
             }
         }
@@ -492,7 +492,7 @@ public class Readability {
             if rougeTables.count > 0 {
                 for table in rougeTables {
                     let code = try table.getElementsByClass("rouge-code").array()[0]
-                    let content = try getInnerText(code.getElementsByTag("pre").array()[0])
+                    let content = try code.getElementsByTag("pre").array()[0].getInnerText()
                     let parent = table.parent()
                     try parent?.text(content)
                 }
@@ -513,7 +513,7 @@ public class Readability {
         do {
             let titleEls = try! dom.getElementsByTag("title")
             if titleEls.count > 0 {
-                origTitle = getInnerText(titleEls[0])
+                origTitle = try! titleEls[0].getInnerText()
             }
 
             curTitle = origTitle
@@ -546,9 +546,9 @@ public class Readability {
             let h1s = try! dom.getElementsByTag("h1")
             if h1s.count > 0 {
                 if h1s.count > 1 {
-                    origTitle = getInnerText(h1s[1])
+                    origTitle = try! h1s[1].getInnerText()
                 } else {
-                    origTitle = getInnerText(h1s.first()!)
+                    origTitle = try! h1s.first()!.getInnerText()
                 }
                 curTitle = origTitle.trimmingCharacters(in: .whitespacesAndNewlines)
                 articleTitle = try! dom.createElement("h1")
@@ -630,7 +630,7 @@ public class Readability {
                 // @parse_url(self.url, PHP_URL_HOST)
             }
 
-            let linkText = getInnerText(articleLink)
+            let linkText = try! articleLink.getInnerText()
 
             if try! articleLink.attr("class").range(of: "readability-DoNotFootnote") != nil {
                 continue
@@ -738,7 +738,7 @@ public class Readability {
             let objectCount = try! article.getElementsByTag("object").array().count
             let iframeCount = try! article.getElementsByTag("iframe").array().count
 
-            if imgCount == 0 && embedCount == 0 && objectCount == 0 && iframeCount == 0 && getInnerText(article, normalizeSpaces: false) == "" {
+            if imgCount == 0 && embedCount == 0 && objectCount == 0 && iframeCount == 0 && (try! article.getInnerText(normalizeSpaces: false)) == "" {
                 try! article.parent()?.removeChild(article)
             }
         }
@@ -879,7 +879,7 @@ public class Readability {
             let parentNode = pt.parent()
             // $grandParentNode = $parentNode ? $parentNode->parentNode : null;
             let grandParentNode = parentNode == nil ? nil : parentNode!.parent()
-            let innerText = getInnerText(pt)
+            let innerText = try! pt.getInnerText()
 
             if parentNode == nil || parentNode!.tagName().isEmpty {
                 continue
@@ -1022,7 +1022,7 @@ public class Readability {
 
             if siblingNode.nodeName().uppercased() == "P" {
                 let linkDensity = getLinkDensity(siblingNode as! Element)
-                let nodeContent = getInnerText(siblingNode as! Element)
+                let nodeContent = try! (siblingNode as! Element).getInnerText()
                 let nodeLength = nodeContent.count
 
                 if nodeLength > 80 && linkDensity < 0.25 {
@@ -1076,7 +1076,7 @@ public class Readability {
          * likelihood of finding the content, and the sieve approach gives us a higher likelihood of
          * finding the -right- content.
          **/
-        if getInnerText(articleContent, normalizeSpaces: false).count < 250 {
+        if try! articleContent.getInnerText(normalizeSpaces: false).count < 250 {
             // TODO: find out why element disappears sometimes, e.g. for this URL http://www.businessinsider.com/6-hedge-fund-etfs-for-average-investors-2011-7
             // in the meantime, we check and create an empty element if it's not there.
             if body?.getChildNodes() == nil {
@@ -1124,30 +1124,6 @@ public class Readability {
     }
 
     /**
-     * Get the inner text of a node.
-     * This also strips out any excess whitespace to be found.
-     *
-     * @param DOMElement $
-     * @param boolean $normalizeSpaces (default: true)
-     * @return string
-     **/
-    public func getInnerText(_ e: Element, normalizeSpaces: Bool = true) -> String {
-        var textContent = ""
-
-        if try! e.text() == "" {
-            return ""
-        }
-
-        textContent = try! e.text().trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if normalizeSpaces {
-            return textContent.replacingOccurrences(of: RegEx.normalize, with: " ")
-        } else {
-            return textContent
-        }
-    }
-
-    /**
      * Get the number of times a string $s appears in the node $e.
      *
      * @param DOMElement $e
@@ -1155,7 +1131,7 @@ public class Readability {
      * @return number (integer)
      **/
     public func getCharCount(_ e: Element, s: String = ",") -> Int {
-        return getInnerText(e).rangesOfString(s: s).count
+        return try! e.getInnerText().rangesOfString(s: s).count
     }
 
     /**
@@ -1181,11 +1157,11 @@ public class Readability {
      */
     public func getLinkDensity(_ e: Element) -> Float {
         let links = try! e.getElementsByTag("a")
-        let textLength = getInnerText(e).count
+        let textLength = try! e.getInnerText().count
         var linkLength = 0
 
         for link in links {
-            linkLength += getInnerText(link).count
+            linkLength += try! link.getInnerText().count
         }
 
         if textLength > 0 {
@@ -1346,7 +1322,7 @@ public class Readability {
                 }
 
                 let linkDensity = getLinkDensity(tag)
-                let contentLength = getInnerText(tag).count
+                let contentLength = try! tag.getInnerText().count
                 var toRemove = false
 
                 if lightClean {

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -947,7 +947,7 @@ public class Readability {
              **/
             let readability = try! cl.attr("readability")
 
-            let value = Float(readability)! * (1 - getLinkDensity(cl))
+            let value = Float(readability)! * (1 - (try! cl.getLinkDensity()))
 
             try! cl.attr("readability", String(value))
 
@@ -1021,7 +1021,7 @@ public class Readability {
             }
 
             if siblingNode.nodeName().uppercased() == "P" {
-                let linkDensity = getLinkDensity(siblingNode as! Element)
+                let linkDensity = try! (siblingNode as! Element).getLinkDensity()
                 let nodeContent = try! (siblingNode as! Element).getInnerText()
                 let nodeLength = nodeContent.count
 
@@ -1120,29 +1120,6 @@ public class Readability {
 
         for script in noscripts {
             try! script.parent()?.removeChild(script)
-        }
-    }
-
-    /**
-     * Get the density of links as a percentage of the content
-     * This is the amount of text that is inside a link divided by the total text in the node.
-     *
-     * @param DOMElement $e
-     * @return number (float)
-     */
-    public func getLinkDensity(_ e: Element) -> Float {
-        let links = try! e.getElementsByTag("a")
-        let textLength = try! e.getInnerText().count
-        var linkLength = 0
-
-        for link in links {
-            linkLength += try! link.getInnerText().count
-        }
-
-        if textLength > 0 {
-            return Float(linkLength / textLength)
-        } else {
-            return 0
         }
     }
 
@@ -1296,7 +1273,7 @@ public class Readability {
                     }
                 }
 
-                let linkDensity = getLinkDensity(tag)
+                let linkDensity = try! tag.getLinkDensity()
                 let contentLength = try! tag.getInnerText().count
                 var toRemove = false
 
@@ -1384,7 +1361,7 @@ public class Readability {
             let headers = try! e.getElementsByTag("h\(headerIndex)").array()
 
             for header in headers {
-                if getClassWeight(header) < 0 || getLinkDensity(header) > 0.33 {
+                if (try! header.getClassWeight()) < 0 || (try! header.getLinkDensity()) > 0.33 {
                     try! header.parent()?.removeChild(header)
                 }
             }

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -784,7 +784,9 @@ public class Readability {
             break
         }
 
-        contentScore += getClassWeight(node)
+        if flagIsActive(flag: FLAG_WEIGHT_CLASSES) {
+            contentScore += try! node.getClassWeight()
+        }
 
         try! node.attr("readability", "\(contentScore)")
     }
@@ -1124,45 +1126,6 @@ public class Readability {
     }
 
     /**
-     * Get an elements class/id weight. Uses regular expressions to tell if this
-     * element looks good or bad.
-     *
-     * @param DOMElement $e
-     * @return number (Integer)
-     */
-    public func getClassWeight(_ e: Element) -> Int {
-        if !flagIsActive(flag: FLAG_WEIGHT_CLASSES) {
-            return 0
-        }
-
-        var weight = 0
-
-        /* Look for a special classname */
-        if try! e.hasAttr("class") && e.attr("class") != "" {
-            if try! e.attr("class").matches(RegEx.negative) {
-                weight -= 25
-            }
-
-            if try! e.attr("class").matches(RegEx.positive) {
-                weight += 25
-            }
-        }
-
-        /* Look for a special ID */
-        if try! e.hasAttr("id") && e.attr("id") != "" {
-            if try! e.attr("id").matches(RegEx.negative) {
-                weight -= 25
-            }
-
-            if try! e.attr("id").matches(RegEx.positive) {
-                weight += 25
-            }
-        }
-
-        return weight
-    }
-
-    /**
      * Remove extraneous break tags from a node.
      *
      * @param DOMElement $node
@@ -1237,7 +1200,7 @@ public class Readability {
          * TODO: Consider taking into account original contentScore here.
          */
         for tag in tagsList {
-            let weight = getClassWeight(tag)
+            let weight = flagIsActive(flag: FLAG_WEIGHT_CLASSES) ? try! tag.getClassWeight() : 0
 
             let contentScore = (tag.hasAttr("readability")) ? try! Int(Float(tag.attr("readability"))!) : 0
 
@@ -1361,7 +1324,8 @@ public class Readability {
             let headers = try! e.getElementsByTag("h\(headerIndex)").array()
 
             for header in headers {
-                if (try! header.getClassWeight()) < 0 || (try! header.getLinkDensity()) > 0.33 {
+                let classWeight = flagIsActive(flag: FLAG_WEIGHT_CLASSES) ? try! header.getClassWeight() : 0
+                if classWeight < 0 || (try! header.getLinkDensity()) > 0.33 {
                     try! header.parent()?.removeChild(header)
                 }
             }

--- a/Sources/Readability/Read.swift
+++ b/Sources/Readability/Read.swift
@@ -1270,3 +1270,87 @@ public class Readability {
         flags = flags & ~flag
     }
 }
+
+public extension Readability {
+    /**
+     * Get the inner text of a node.
+     * This also strips out any excess whitespace to be found.
+     *
+     * @param DOMElement $
+     * @param boolean $normalizeSpaces (default: true)
+     * @return string
+     **/
+    func getInnerText(_ e: Element, normalizeSpaces: Bool = true) -> String {
+        try! e.getInnerText(normalizeSpaces: normalizeSpaces)
+    }
+
+    /**
+     * Get the number of times a string $s appears in the node $e.
+     *
+     * @param DOMElement $e
+     * @param string - what to count. Default is ","
+     * @return number (integer)
+     **/
+    func getCharCount(_ e: Element, s: String = ",") -> Int {
+        try! e.getInnerText().rangesOfString(s: s).count
+    }
+
+    /**
+     * Remove the style attribute on every $e and under.
+     *
+     * @param DOMElement $e
+     * @return void
+     */
+    func cleanStyles(_ e: Element) {
+        try! e.cleanStyles()
+    }
+
+    /**
+     * Get the density of links as a percentage of the content
+     * This is the amount of text that is inside a link divided by the total text in the node.
+     *
+     * @param DOMElement $e
+     * @return number (float)
+     */
+    func getLinkDensity(_ e: Element) -> Float {
+        try! e.getLinkDensity()
+    }
+
+    /**
+     * Get an elements class/id weight. Uses regular expressions to tell if this
+     * element looks good or bad.
+     *
+     * @param DOMElement $e
+     * @return number (Integer)
+     */
+    func getClassWeight(_ e: Element) -> Int {
+        if !flagIsActive(flag: FLAG_WEIGHT_CLASSES) {
+            return 0
+        }
+        return try! e.getClassWeight()
+    }
+
+    /**
+     * Clean a node of all elements of type "tag".
+     * (Unless it's a youtube/vimeo video. People love movies.)
+     *
+     * Updated 2012-09-18 to preserve youtube/vimeo iframes
+     *
+     * @param DOMElement $e
+     * @param string $tag
+     * @return void
+     */
+    func clean(_ e: Element, tag: String) {
+        try! e.clean(tag: tag)
+    }
+
+    /**
+     * Clean out spurious headers from an Element. Checks things like classnames and link density.
+     *
+     * @param DOMElement $e
+     * @return void
+     */
+    func cleanHeaders(_ e: Element) {
+        try! e.cleanHeaders(getClassWeight: flagIsActive(flag: FLAG_WEIGHT_CLASSES))
+    }
+}

--- a/Sources/Readability/RegEx.swift
+++ b/Sources/Readability/RegEx.swift
@@ -1,0 +1,23 @@
+//
+//  RegEx.swift
+//  
+//
+//  Created by Mathew Gacy on 5/28/23.
+//  
+//
+
+import Foundation
+
+/// All of the regular expressions in use within readability.
+public enum RegEx {
+    static let unlikelyCandidates = "/combx|comment|community|disqus|extra|header|menu|remark|rss|shoutbox|sidebar|sponsor|ad-break|agegate|pagination|pager|popup/i"
+    static let okMaybeItsACandidate = "/and|article|body|column|main|shadow|instapaper_body|post/i"
+    static let positive = "/article|body|content|entry|hentry|main|page|attachment|pagination|post|text|footnote|blog|story/i"
+    static let negative = "/combx|comment|com-|contact|foot|footer|_nav|masthead|media|meta|outbrain|promo|related|scroll|shoutbox|sidebar|sponsor|shopping|tags|tool|widget/i"
+    static let divToPElements = "/<(a|blockquote|dl|div|img|ol|p|pre|table|ul)/i"
+    static let replaceBrs = "/(<br[^>]*>[ \\n\\r\\t]*){2,}/i"
+    static let replaceFonts = "/<(/?)font[^>]*>/i"
+    static let normalize = "/\\s{2,}/"
+    static let killBreaks = "/(<br\\s*/?>(\\s|&nbsp;?)*){1,}/"
+    static let video = "///(player\\.|www\\.)?(youtube\\.com|vimeo\\.com|viddler\\.com|twitch\\.tv)/i"
+}


### PR DESCRIPTION
Moves `Readability.regexps` to static members on a `RegEx` type so they can be shared and refactors the logic from `Readability` methods that mutate or return values on `Element`s as methods on `Element`. This also makes those methods throwing. The intention is to make the `Readability` class more focused (and thus more readable).